### PR TITLE
Output contract balance log after 1st wave

### DIFF
--- a/1-ETH-dApp/ja/section-4/Lesson_1_WEBアプリに抽選機能を実装しよう.md
+++ b/1-ETH-dApp/ja/section-4/Lesson_1_WEBアプリに抽選機能を実装しよう.md
@@ -179,6 +179,15 @@ const main = async () => {
    */
   const waveTxn = await waveContract.wave("This is wave #1");
   await waveTxn.wait();
+  
+  /*
+   * コントラクトのバランスを取得し、Waveを取得した後の結果を出力
+   */
+  contractBalance = await hre.ethers.provider.getBalance(waveContract.address);
+  console.log(
+    "Contract balance:",
+    hre.ethers.utils.formatEther(contractBalance)
+  );
 
   const waveTxn2 = await waveContract.wave("This is wave #2");
   await waveTxn2.wait();
@@ -229,6 +238,7 @@ Contract balance: 0.1
 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 has waved!
 Random # generated: 89
 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 did not win.
+Contract balance: 0.1
 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 has waved!
 Random # generated: 31
 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 won!


### PR DESCRIPTION
変更：１回目のwaveの後にもコントラクトバランスをログ出力をするようにした
目的：コントラクトバランスの変化を可視化するため