### PR TITLE
コード実行前のディレクトリ移動作業の追記

### DIFF
--- a/2-ETH-NFT-collection/ja/section-1/Lesson_3_ローカル環境でNFTをmintしよう.md
+++ b/2-ETH-NFT-collection/ja/section-1/Lesson_3_ローカル環境でNFTをmintしよう.md
@@ -208,7 +208,7 @@ console.log("Contract deployed to:", nftContract.address);
 
 では、実行してみましょう。
 
-ターミナルを開いて、下記を実行してください。
+ターミナルを開いて`epic-nfts`ディレクトリへ移動し、下記を実行してください。
 
 ```bash
 npx hardhat run scripts/run.js


### PR DESCRIPTION
直前の作業でscriptsディレクトリへ移動していたため、こちらに記載のコード(npx hardhat run scripts/run.js)をそのまま実行すると以下エラーが出ました。
Error HH601: Script scripts/run.js doesn't exist.
自分がscriptsディレクトリにいることを確認できればすぐ解消するエラーなのですが、念のためディレクトリ移動が必要な旨追記しても良いかと思い、プルリクを作成させていただきます…！